### PR TITLE
Fix attribute naming bug in ROI

### DIFF
--- a/src/Gesture_Controller_Gloved.py
+++ b/src/Gesture_Controller_Gloved.py
@@ -106,7 +106,7 @@ class ROI:
         self.hsv_corners = None
         
         self.marker_top = None
-        self.glove_hsv = None
+        self.hsv_glove = None
         
     def findROI(self, frame, marker):
         rec_coor = marker.corners[0][0]


### PR DESCRIPTION
## Summary
- fix inconsistent attribute name `glove_hsv` vs `hsv_glove`

## Testing
- `python -m py_compile src/Gesture_Controller_Gloved.py`


------
https://chatgpt.com/codex/tasks/task_e_686c60605b34832b81d3bd019d6527a2