### PR TITLE
Fix assistant typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Note: Use Python version: 3.8.5
   <ul>
     <li>
       <code> Proton Exit </code> <br>
-      Terminates the voice assisstant thread. GUI window needs to be closed manually.
+      Terminates the voice assistant thread. GUI window needs to be closed manually.
     </li>
   </ul>
 </details>


### PR DESCRIPTION
## Summary
- fix the word 'assistant' in the Proton Exit section of README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6247ca18832bb1015519ba443826