### PR TITLE
Fix ratio fallback in HandRecog

### DIFF
--- a/src/Gesture_Controller.py
+++ b/src/Gesture_Controller.py
@@ -160,9 +160,9 @@ class HandRecog:
             dist2 = self.get_signed_dist(point[1:])
             
             try:
-                ratio = round(dist/dist2,1)
+                ratio = round(dist/dist2, 1)
             except:
-                ratio = round(dist1/0.01,1)
+                ratio = round(dist/0.01, 1)
 
             self.finger = self.finger << 1
             if ratio > 0.5 :


### PR DESCRIPTION
## Summary
- fix typo in `HandRecog.set_finger_state`

## Testing
- `python -m py_compile src/Gesture_Controller.py`

------
https://chatgpt.com/codex/tasks/task_e_686c62493dc0832b99dd4acce47452d9